### PR TITLE
replace slash with backslash to handle windows filepaths

### DIFF
--- a/source/code/urequire-ab-specrunner.coffee
+++ b/source/code/urequire-ab-specrunner.coffee
@@ -232,7 +232,7 @@ module.exports = specRunner = (err, specBB, options)->
     mochaParams  = _.filter ((options.mochaOptions or '') + ' ' + filename).split /\s/
     l.deb 30, "Running shell `#{cmd} #{mochaParams.join ' '}`"
     if not options.exec #default
-      cmd += '.cmd' if process.platform is "win32" # solves ENOENT http://stackoverflow.com/questions/17516772/using-nodejss-spawn-causes-unknown-option-and-error-spawn-enoent-err
+      cmd = cmd.replace(/\//g, '\\') + '.cmd' if process.platform is "win32" # solves ENOENT http://stackoverflow.com/questions/17516772/using-nodejss-spawn-causes-unknown-option-and-error-spawn-enoent-err
       l.ok "spawn-ing `#{cmd} #{mochaParams.join ' '}`"
       When.promise (resolve, reject)->
         cp = spawn cmd, mochaParams


### PR DESCRIPTION
There was a bug when trying to start the mochaShell because it was trying to access ./node_modules/.bin/mocha. This works fine in Unix enviroments but in windows the paths use backslashes ('\\') instead of slashes ('/'), so this was making the execution fail when running it on windows.